### PR TITLE
Update access-control.yaml

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -430,6 +430,7 @@ teams:
       - sownak
     members:
       - adityajoshi12
+      - alvaropicazo
       - arsulegai
       - dviejokfs
       - jagpreetsinghsasan
@@ -454,7 +455,7 @@ teams:
     maintainers:
       - jonathan-m-hamilton
     members:
-      - ravikiranjanjanam
+      - alvaropicazo
       - saikumarbommakanti
       - saurabhkumarkardam
       - suvajit-sarkar


### PR DESCRIPTION
Added new user to the bevel team, and removed an user.
[bevel-triage](https://github.com/orgs/hyperledger/teams/bevel-triage) does not reflect the users properly. Missing `saikumarbommakanti`