### PR TITLE
chore: update indy maintainers

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -1083,6 +1083,7 @@ teams:
       - andrewwhitehead
     members:
       - pSchlarb
+      - PatStLouis
   - name: indy-rfc-maintainers
     maintainers:
       - TelegramSam

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -988,9 +988,13 @@ teams:
   - name: indy-admin
     maintainers:
       - WadeBarnes
-      - dhh1128
-      - esplinr
-      - nage
+      - swcurran
+      - reflectivedevelopment
+      - PatStLouis
+      - Toktar
+      - lynnbendixsen
+      - TelegramSam
+      - cjhowland
     members:
       - andrewwhitehead
       - swcurran

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -997,7 +997,6 @@ teams:
       - cjhowland
     members:
       - andrewwhitehead
-      - swcurran
   - name: indy-agent-maintainers
     maintainers:
       - nage

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -1547,6 +1547,7 @@ teams:
       - outsidethecode
       - pSchlarb
       - patlo-iog
+      - PatStLouis
       - paul-cpp
       - paulbastian
       - peacekeeper

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -990,12 +990,12 @@ teams:
       - WadeBarnes
       - swcurran
       - reflectivedevelopment
-      - PatStLouis
       - Toktar
       - lynnbendixsen
       - TelegramSam
       - cjhowland
     members:
+      - PatStLouis
       - andrewwhitehead
   - name: indy-agent-maintainers
     maintainers:


### PR DESCRIPTION
This PR adds the following to the Indy maintainers list: @swcurran, @reflectivedevelopment, @PatStLouis, @Toktar, @lynnbendixsen, @TelegramSam, @cjhowland.

This PR also removes the following due to inactivity: @dhh1128, @esplinr, @nage.
