### PR TITLE
add users to besu-contributors and write perms

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -350,7 +350,7 @@ teams:
       - macfarla
       - shemnon
     members:
-      - NicolasMassart
+      - non-fungible-nelson
       - ajsutton
       - atoulme
       - bgravenorst
@@ -2052,7 +2052,7 @@ repositories:
   - name: besu
     teams:
       besu-admin: admin
-      besu-contributors: triage
+      besu-contributors: write
       besu-docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage
@@ -2074,7 +2074,7 @@ repositories:
   - name: besu-errorprone-checks
     teams:
       besu-admin: admin
-      besu-contributors: read
+      besu-contributors: triage
       besu-docs-maintainers: read
       besu-maintainers: maintain
       besu-triage: read

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -350,6 +350,7 @@ teams:
       - macfarla
       - shemnon
     members:
+      - ConsensysOps
       - non-fungible-nelson
       - kkaur01
   - name: besu-docs-maintainers
@@ -395,7 +396,6 @@ teams:
       - NickSneo
       - cdivitotawela
       - cloudspores
-      - ConsensysOps
       - ensi321
       - gtebrean
       - kkaur01

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -352,6 +352,7 @@ teams:
     members:
       - ConsensysOps
       - non-fungible-nelson
+      - cdivitotawela
       - kkaur01
   - name: besu-docs-maintainers
     maintainers:

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -2053,7 +2053,7 @@ repositories:
   - name: besu-docs
     teams:
       besu-admin: admin
-      besu-contributors: triage
+      besu-contributors: write
       besu-docs-maintainers: admin
       besu-maintainers: triage
       besu-triage: triage
@@ -2064,7 +2064,7 @@ repositories:
   - name: besu-errorprone-checks
     teams:
       besu-admin: admin
-      besu-contributors: triage
+      besu-contributors: write
       besu-docs-maintainers: read
       besu-maintainers: maintain
       besu-triage: read
@@ -2075,7 +2075,7 @@ repositories:
   - name: besu-native
     teams:
       besu-admin: admin
-      besu-contributors: triage
+      besu-contributors: write
       besu-docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage
@@ -2086,7 +2086,7 @@ repositories:
   - name: besu-verkle-trie
     teams:
       besu-admin: admin
-      besu-contributors: triage
+      besu-contributors: write
       besu-docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage
@@ -2636,7 +2636,7 @@ repositories:
   - name: homebrew-besu
     teams:
       besu-admin: admin
-      besu-contributors: triage
+      besu-contributors: write
       besu-docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -351,17 +351,7 @@ teams:
       - shemnon
     members:
       - non-fungible-nelson
-      - ajsutton
-      - atoulme
-      - bgravenorst
-      - gfukushima
-      - joshuafernandes
       - kkaur01
-      - lucassaldanha
-      - matkt
-      - mbaxter
-      - pinges
-      - usmansaleem
   - name: besu-docs-maintainers
     maintainers:
       - bgravenorst


### PR DESCRIPTION
add Matt Nelson, Chaminda Divitotawela and `ConsensysOps` to besu-contributors and give this group write access to besu repos (they previously had access via besu-triage group having write access)