### PR TITLE
Update access-control.yaml after the Atala Team restructure

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -946,15 +946,16 @@ teams:
     members:
       - FabioPinheiro
       - amagyar-iohk
+      - elribonazo
+  - name: identus-maintainers
+    maintainers:
+      - yshyn-iohk
+    members:
+      - essbante-io    
+      - womfoo
       - milosbackonja
       - patlo-iog
       - Dale-iohk
-      - elribonazo
-      - womfoo
-  - name: identus-maintainers
-    maintainers:
-      - essbante-io
-    members:
       - CryptoKnightIOG
       - EzequielPostan
       - FabioPinheiro
@@ -975,7 +976,6 @@ teams:
       - patlo-iog
       - petevielhaber
       - shotexa
-      - yshyn-iohk
       - womfoo
       - Dale-iohk
       - atala-dev


### PR DESCRIPTION
The following actions were applied:
1. moved @essbante-io from maintainers to members of the @hyperledger/identus-maintainers 
2. moved @yshyn-iohk from the members to the maintainers of the @hyperledger/identus-maintainers 
3. moved the following GitHub ids from the @hyperledger/identus-admins team to the @hyperledger/identus-maintainers team:
- @milosbackonja
- @patlo-iog 
- @Dale-iohk 
- @womfoo 
