### PR TITLE
Add identus-vdr repository

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -2343,7 +2343,15 @@ repositories:
       identus-maintainers: maintain
       security-managers: read
       toc: read
-    visibility: private         
+    visibility: private  
+  - name: identus-vdr
+    collaborators:
+    teams:
+      identus-admins: admin
+      identus-maintainers: maintain
+      security-managers: read
+      toc: read
+    visibility: public   
   - name: indy
     teams:
       indy-admin: admin


### PR DESCRIPTION
`identus-vdr` is a repository required for working on https://github.com/hyperledger/identus/issues/70 and https://github.com/hyperledger/identus/issues/71