### PR TITLE
update besu triage group membership

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -276,7 +276,6 @@ teams:
       - NickSneo
       - gtebrean
       - kkaur01
-      - shemnon
   - name: fabric-admin-sdk-maintainers
     maintainers:
       - denyeart


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>
Remove shemnon per request, to also match https://github.com/besu-eth/governance