### PR TITLE
access-control: firefly-cardano group

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -574,9 +574,10 @@ teams:
       - alex-semenyuk
   - name: firefly-cardano
     maintainers:
+      - EnriqueL8
+    members:
       - SupernaviX
       - Quantumplation
-    members:
       - mmahut
   - name: firefly-tokens-erc1155-maintainers
     maintainers:

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -572,6 +572,12 @@ teams:
     members:
       - denisandreenko
       - alex-semenyuk
+  - name: firefly-cardano
+    maintainers:
+      - SupernaviX
+      - Quantumplation
+    members:
+      - mmahut
   - name: firefly-tokens-erc1155-maintainers
     maintainers:
       - peterbroadhurst
@@ -1652,6 +1658,16 @@ repositories:
       firefly-admins: admin
       firefly-contributors: read
       firefly-tezosconnect-maintainers: maintain
+      read-only: read
+      security-managers: read
+      toc: read
+    visibility: public
+  - name: firefly-cardano
+    teams:
+      firefly: read
+      firefly-admins: admin
+      firefly-contributors: read
+      firefly-cardano: maintain
       read-only: read
       security-managers: read
       toc: read


### PR DESCRIPTION
As a preparation for the [firefly-cardano](https://github.com/blockfrost/firefly-cardano) repository handover, I'm opening a request for access-control.