### PR TITLE
besu: remove mbaxter per 8710

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -209,7 +209,6 @@ teams:
       - Matilda-Clerke
       - matkt
       - matthew1001
-      - mbaxter
       - pinges
       - pullurib
       - siladu


### PR DESCRIPTION
remove @mbaxter from besu maintainers per https://github.com/hyperledger/besu/pull/8710