### PR TITLE
rejoin team: fabric-zh-cn-doc-maintainers

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -345,6 +345,7 @@ teams:
     maintainers:
       - yeasy
     members:
+      - davidkhala
   - name: firefly
     maintainers:
       - EnriqueL8


### PR DESCRIPTION
I found myself get removed since implementation of new governance model. Now I want to rejoin as a member that can accelerate doc PR review process. 