### PR TITLE
Adding @bryce-mcmath to the anoncreds-rs (and wrapper) and indy-vdr teams as a member

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -13,6 +13,7 @@ teams:
     members:
       - TelegramSam
       - dkulic
+      - bryce-mcmath
   - name: anoncreds-maintainers
     maintainers:
       - swcurran
@@ -637,6 +638,7 @@ teams:
       - berendsliedrecht
       - ianco
       - esune
+      - bryce-mcmath
   - name: lf-employees
     maintainers:
       - SeanBohan


### PR DESCRIPTION
Adding @bryce-mcmath to the anoncreds-rs (and wrapper) and indy-vdr teams as a member.  Needs to have the CI/CD actions happening automagically when submitting PRs, and he has a number of PRs to do.  @bryce-mcmath is part of the BC Gov team and is a maintainer on OWF Bifold Wallet and the BC Wallet.